### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ Tests can be run using the following
 yarn test
 ```
 
+### Env Variables
+
+Configuration for the ingestion is provided via environment variables.
+
+* `BUCKET`: The bucket to which the ingested data should be written. **Required**
+* `SOURCE`: The [data source](#data-sources) to ingest. **Required**
+* `LCS_API`: The API used when fetching supported measurands. _Default: `'https://api.openaq.org'`_
+* `STACK`: The stack to which the ingested data should be associated. This is mainly used to apply a prefix to data uploaded to S3 in order to separate it from production data. _Default: `'local'`_
+* `SECRET_STACK`: The stack to which the used [Secrets](#provider-secrets) are associated. At times, a developer may want to use credentials relating to a different stack (e.g. a devloper is testing the script, they want output data uploaded to the `local` stack but want to use the production stack's secrets). _Default: the value from the `STACK` env variable_
+* `VERBOSE`: Enable verbose logging. _Default: disabled_
+
 ### Running locally
 
 To run the ingestion script locally (useful for testing without deploying), see the following example:
@@ -35,17 +46,6 @@ VERBOSE=1 \
 SOURCE=habitatmap \
 node fetcher/index.js
 ```
-
-### Env Variables
-
-Configuration for the ingestion is provided via environment variables.
-
-* `BUCKET`: The bucket to which the ingested data should be written. **Required**
-* `SOURCE`: The data source to ingest. **Required**
-* `LCS_API`: The API used when fetching supported measurands. _Default: `'https://api.openaq.org'`_
-* `STACK`: The stack to which the ingested data should be associated. This is mainly used to apply a prefix to data uploaded to S3 in order to separate it from production data. _Default: `'local'`_
-* `SECRET_STACK`: The stack to which the used [Secrets](#provider-secrets) are associated. At times, a developer may want to use credentials relating to a different stack (e.g. a devloper is testing the script, they want output data uploaded to the `local` stack but want to use the production stack's secrets). _Default: the value from the `STACK` env variable_
-* `VERBOSE`: Enable verbose logging. _Default: disabled_
 
 ## Data Sources
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,31 @@ Tests can be run using the following
 yarn test
 ```
 
+### Running locally
+
+To run the ingestion script locally (useful for testing without deploying), see the following example:
+
+```sh
+LCS_API=https://api.openaq.org \
+STACK=my-dev-stack \
+SECRET_STACK=my-prod-stack \
+BUCKET=openaq-fetches \
+VERBOSE=1 \
+SOURCE=habitatmap \
+node fetcher/index.js
+```
+
+### Env Variables
+
+Configuration for the ingestion is provided via environment variables.
+
+* `BUCKET`: The bucket to which the ingested data should be written. **Required**
+* `SOURCE`: The data source to ingest. **Required**
+* `LCS_API`: The API used when fetching supported measurands. _Default: `'https://api.openaq.org'`_
+* `STACK`: The stack to which the ingested data should be associated. This is mainly used to apply a prefix to data uploaded to S3 in order to separate it from production data. _Default: `'local'`_
+* `SECRET_STACK`: The stack to which the used [Secrets](#provider-secrets) are associated. At times, a developer may want to use credentials relating to a different stack (e.g. a devloper is testing the script, they want output data uploaded to the `local` stack but want to use the production stack's secrets). _Default: the value from the `STACK` env variable_
+* `VERBOSE`: Enable verbose logging. _Default: disabled_
+
 ## Data Sources
 
 Data Sources can be configured by adding a config file & corresponding provider script. The two sections below
@@ -29,7 +54,7 @@ outline what is necessary to create and a new source.
 
 ### Source Config
 
-The first step for a new source is to add an entry to the array located in the `lib/sources.js` directory.
+The first step for a new source is to add JSON config file to the the `fetcher/lib/sources` directory.
 
 
 ```json
@@ -54,7 +79,7 @@ provider script. The above table however outlines the attributes that are requir
 
 ### Provider Script
 
-The second step is to add a new provider script to the `lib/providers/` directory.
+The second step is to add a new provider script to the `fetcher/lib/providers` directory.
 
 The script here should expose a function named `processor` and should pass
 `SensorSystem` & `Measures` objects to the `Providers` class.
@@ -76,22 +101,22 @@ async function processor(source_name, source) {
 
     await Providers.put_stations(source_name, [ station ]);
 
-    const fmeasures = new Measures(FixedMeasure);
+    const fixed_measures = new Measures(FixedMeasure);
     // or
-    const mmeasures = new Measures(MobileMeasure);
+    const mobile_measures = new Measures(MobileMeasure);
 
-    fmeasures.push(new FixedMeasure({
+    fixed_measures.push(new FixedMeasure({
         sensor_id: 'PurpleAir-123',
         measure: 123,
         timestamp: Math.floor(new Date() / 1000) //UNIX Timestamp
     }));
 
-    await Providers.put_measures(source_name, fmeasures);
+    await Providers.put_measures(source_name, fixed_measures);
 }
 
 module.exports = { processor };
 ```
 
-### Secrets
+### Provider Secrets
 
 For data providers that require credentials, credentials should be store on AWS Secrets Manager with an ID composed of the stack name and provider name, such as `:stackName/:providerName`.

--- a/fetcher/lib/measurand.js
+++ b/fetcher/lib/measurand.js
@@ -43,7 +43,7 @@ class Measurand {
         let morePages;
         let page = 1;
         do {
-            const url = new URL('/v2/parameters', process.env.LCS_API);
+            const url = new URL('/v2/parameters', process.env.LCS_API || 'https://api.openaq.org');
             url.searchParams.append('page', page++);
             const { body: { meta, results } } = await request({
                 json: true,

--- a/fetcher/lib/measurand.js
+++ b/fetcher/lib/measurand.js
@@ -33,8 +33,12 @@ class Measurand {
     }
 
     /**
+     * Given a map of lookups from an input parameter (i.e. how a data provider
+     * identifies a measurand) to a tuple of a measurand parameter (i.e. how we
+     * idenify a measurand internally) and a measurand unit, generate an array
+     * Measurand objects that are supported by the OpenAQ API.
      *
-     * @param {*} lookups
+     * @param {*} lookups, e.g. {'CO': ['co', 'ppb'] }
      * @returns { Measurand[] }
      */
     static async getSupportedMeasurands(lookups) {


### PR DESCRIPTION
This PR makes the following changes:

1. Adds documentation describing how to run the ingestion script locally
2. Adds documentation about the purpose of supported environment variables
3. Updates the documentation to match the recent repo changes where sources are described in individual config files.
4. Small cleanups in the documentation for legibility
5. Improves docstring to `Measurand.getSupportedMeasurands` method
6. Adds support for defaulting to prod URL (`https://api.openaq.org`) for `LCS_API` env variable