### PR TITLE
Ensure measurand names are unique, support overriding

### DIFF
--- a/fetcher/lib/providers.js
+++ b/fetcher/lib/providers.js
@@ -94,10 +94,12 @@ class Providers {
      *
      * @param {string} provider The name of the provider (ie purpleair)
      * @param {Measures} measures A measurements object of measures
+     * @param {string} id An optional identifier to use when creating filename
      */
-    static async put_measures(provider, measures) {
+    static async put_measures(provider, measures, id) {
         const Bucket = process.env.BUCKET;
-        const Key = `${process.env.STACK}/measures/${provider}/${Math.floor(Date.now() / 1000)}.csv.gz`;
+        const filename = id || `${Math.floor(Date.now() / 1000)}-${Math.random().toString(36).substring(8)}`;
+        const Key = `${process.env.STACK}/measures/${provider}/${filename}.csv.gz`;
         const compressedString = await gzip(measures.csv());
         return s3.putObject({
             Bucket,

--- a/fetcher/providers/cmu.js
+++ b/fetcher/providers/cmu.js
@@ -176,7 +176,8 @@ async function processFile({ file, timestamp, stations, source_name, drive, meas
             });
         }
     }
-    return Providers.put_measures(source_name, measures);
+    const filename = file.name.endsWith('.csv') ? file.name.slice(0, -4) : file.name;
+    return Providers.put_measures(source_name, measures, filename);
 }
 
 class Filename {


### PR DESCRIPTION
This PR appends a random string to measures as they're written to S3, ensuring there will be no conflict in situations multiple files being written to S3 at the same moment.

Additionally, this PR adds support for an override so that providers (e.g. CMU) can specify the measurement's output filename.  