### PR TITLE
Correctly label sensor ID for CMU measurs

### DIFF
--- a/fetcher/providers/cmu.js
+++ b/fetcher/providers/cmu.js
@@ -166,12 +166,12 @@ async function processFile({ file, timestamp, stations, source_name, drive, meas
         }
 
         // Register measurements
-        for (const lookup of measurands) {
-            const measure = row[lookup.input_param];
+        for (const measurand of measurands) {
+            const measure = row[measurand.input_param];
             if ([undefined, null, 'NaN'].includes(measure)) continue;
             measures.push({
-                sensor_id: getSensorId(sensorNodeId, lookup.measurand_parameter),
-                measure: lookup.normalize_value(measure),
+                sensor_id: getSensorId(sensorNodeId, measurand.parameter),
+                measure: measurand.normalize_value(measure),
                 timestamp: timestamp.toISOString()
             });
         }


### PR DESCRIPTION
Fixes a bug where CMU measurement data was being written with invalid sensor IDs.