### PR TITLE
Avoid writing empty CSVs

### DIFF
--- a/fetcher/lib/measure.js
+++ b/fetcher/lib/measure.js
@@ -25,15 +25,13 @@ class Measures {
 
     csv() {
         const csvStringifier = createCsvStringifier({
-            header: this.headers.map((head) => {
-                return {
-                    id: head,
-                    name: head
-                };
-            })
+            header: this.headers.map((head) => ({
+                id: head,
+                title: head
+            }))
         });
 
-        return csvStringifier.getHeaderString() + '\n' + csvStringifier.stringifyRecords(this.measures);
+        return csvStringifier.stringifyRecords(this.measures);
     }
 }
 

--- a/fetcher/lib/providers.js
+++ b/fetcher/lib/providers.js
@@ -96,6 +96,8 @@ class Providers {
      * @param {Measures} measures A measurements object of measures
      */
     static async put_measures(provider, measures) {
+        if (!measures.length)
+            return console.warn('No measures found, not uploading to S3.');
         const Bucket = process.env.BUCKET;
         const Key = `${process.env.STACK}/measures/${provider}/${Math.floor(Date.now() / 1000)}.csv.gz`;
         const compressedString = await gzip(measures.csv());

--- a/fetcher/providers/habitatmap.js
+++ b/fetcher/providers/habitatmap.js
@@ -23,6 +23,9 @@ async function process_fixed_locations(source_name, source, measurands) {
     const measures = new Measures(FixedMeasure);
 
     const locations = await fixed_locations(source);
+    if (!locations.length) {
+        return console.warn('No fixed locations returned, exiting.');
+    }
     console.log(`ok - pulled ${locations.length} fixed stations`);
 
     for (const location of locations) {
@@ -72,6 +75,9 @@ async function process_mobile_locations(source_name, source, measurands) {
     const measures = new Measures(MobileMeasure);
 
     const locations = await mobile_locations(source);
+    if (!locations.length) {
+        return console.warn('No mobile locations returned, exiting.');
+    }
     console.log(`ok - pulled ${locations.length} mobile stations`);
 
     for (const location of locations) {


### PR DESCRIPTION
This PR resolves two issues:

1. CSVs were incorrectly writing their headers, causing each CSV to begin with an empty header row and then an unnecessary blank line:
    ```csv
    ,,
    
    CMU-Braddock Farm-co,0.140963797583384,2019-03-01T05:15:00.000Z
    CMU-Braddock Farm-no2,0.00778049515028079,2019-03-01T05:15:00.000Z
    CMU-Braddock Farm-o3,0.0295454023837332,2019-03-01T05:15:00.000Z
    CMU-Braddock Farm-pm25,15.7288114024361,2019-03-01T05:15:00.000Z
    ```
    This PR removes the functionality around writing the header to the CSV, which will yield in smaller uploads (and thus lower data retention costs).
1. If a measurements file is empty, avoid writing it to S3.