### PR TITLE
Updated logging and dry run option for clarity

### DIFF
--- a/fetcher/lib/providers.js
+++ b/fetcher/lib/providers.js
@@ -69,7 +69,7 @@ class Providers {
         try {
             const resp = await s3.getObject({ Bucket, Key }).promise();
             const currentData = (await unzip(resp.Body)).toString('utf-8');
-            if (currentData === newData) {
+            if (currentData === newData && !process.env.FORCE) {
                 if (VERBOSE) console.log(`station has not changed - station: ${providerStation}`);
                 return;
             }

--- a/fetcher/lib/utils.js
+++ b/fetcher/lib/utils.js
@@ -52,6 +52,33 @@ function toCamelCase(phrase) {
         .join('');
 }
 
+
+/**
+ * Print out JSON station object
+ * @param {obj} station
+ */
+function prettyPrintStation(station) {
+    if(typeof(station)==='string') {
+        station = JSON.parse(station);
+    }
+    for (const [key, value] of Object.entries(station)) {
+        if(key !== 'sensor_systems') {
+            console.log(`${key}: ${value}`);
+        } else {
+            console.log(`Sensor systems`);
+            value.map( ss => {
+                for (const [ky, vl] of Object.entries(ss)) {
+                    if(ky !== 'sensors') {
+                        console.log(`-- ${ky}: ${vl}`);
+                    } else {
+                        vl.map(s => console.debug(`---- ${s.sensor_id} - ${s.measurand_parameter} ${s.measurand_unit}`));
+                    }
+                }
+            });
+        };
+    }
+}
+
 const gzip = promisify(zlib.gzip);
 const unzip = promisify(zlib.unzip);
 
@@ -61,5 +88,7 @@ module.exports = {
     toCamelCase,
     gzip,
     unzip,
-    VERBOSE
+    VERBOSE,
+    DRYRUN,
+    prettyPrintStation,
 };

--- a/fetcher/lib/utils.js
+++ b/fetcher/lib/utils.js
@@ -4,6 +4,7 @@ const request = promisify(require('request'));
 const AWS = require('aws-sdk');
 
 const VERBOSE = !!process.env.VERBOSE;
+const DRYRUN = !!process.env.DRYRUN;
 
 /**
  * Retrieve secret from AWS Secrets Manager

--- a/fetcher/providers/clarity.js
+++ b/fetcher/providers/clarity.js
@@ -86,7 +86,10 @@ class ClarityApi {
             headers: { 'X-API-Key': this.apiKey },
             url: new URL('v1/datasources', this.baseUrl)
         }).then((response) => {
-            const ds = response.body;
+            var ds = response.body;
+            if(process.env.SOURCEID) {
+                ds = ds.filter(d => d.deviceCode == process.env.SOURCEID);
+            }
             if (VERBOSE) {
                 console.log(`-------------------\nListing ${ds.length} sources for ${this.org.organizationName}`);
                 ds.map(d => console.log(`${d.deviceCode} - ${d.name} - ${d.group}`));
@@ -106,6 +109,10 @@ class ClarityApi {
             headers: { 'X-API-Key': this.apiKey },
             url: new URL('v1/devices', this.baseUrl)
         }).then((response) => response.body).then((response) => {
+            if(process.env.SOURCEID) {
+                response = response.filter(d => d.code == process.env.SOURCEID);
+                console.debug(`Limiting sensors to ${process.env.SOURCEID}, found ${response.length}`);
+            }
             const working = response.filter((o) => o.lifeStage === 'working');
             if (VERBOSE) {
                 console.debug(`-----------------\nListing devices for ${this.org.organizationName}\nFound ${response.length} total devices, ${working.length} working`);

--- a/fetcher/providers/clarity.js
+++ b/fetcher/providers/clarity.js
@@ -269,7 +269,7 @@ class ClarityApi {
         }
 
         if(successes < devices.length) {
-            console.warn(`There were ${successes} successful requests out of ${devices.length}`);
+            console.warn(`There were ${successes} successful requests out of ${devices.length}\n------------------------------`);
         }
         await Promise.all([
             ...stations,

--- a/fetcher/providers/purpleair.js
+++ b/fetcher/providers/purpleair.js
@@ -114,7 +114,7 @@ async function fetchSensorData(source, apiKey) {
             'ozone1'
         ].join(',')
     );
-    url.searchParams.append('max_age', 750); // Filter results to only include sensors modified or updated within the last number of seconds.
+    url.searchParams.append('max_age', 75); // Filter results to only include sensors modified or updated within the last number of seconds.
     url.searchParams.append('location_type', 0); // Filter results to only include outdoor sensors.
 
     const { body: { fields, data } } = await request({

--- a/fetcher/providers/purpleair.js
+++ b/fetcher/providers/purpleair.js
@@ -2,7 +2,7 @@ const Providers = require('../lib/providers');
 const { Sensor, SensorNode, SensorSystem } = require('../lib/station');
 const { Measures, FixedMeasure } = require('../lib/measure');
 const { Measurand } = require('../lib/measurand');
-const { fetchSecret, request } = require('../lib/utils');
+const { VERBOSE, fetchSecret, request } = require('../lib/utils');
 
 const lookup = {
     // input_param: [measurand_parameter, measurand_unit]
@@ -23,7 +23,7 @@ const lookup = {
 };
 
 async function processor(source_name, source) {
-    const [
+    var [
         measurands,
         sensorReadings
     ] = await Promise.all([
@@ -35,7 +35,12 @@ async function processor(source_name, source) {
     const stations = [];
     const measures = new Measures(FixedMeasure);
 
-    console.log(`ok - pulled ${sensorReadings.length} stations`);
+    if(VERBOSE) console.log(`ok - pulled ${sensorReadings.length} stations`);
+
+    if(process.env.SOURCEID) {
+        sensorReadings = sensorReadings.filter(d => d.sensor_index == process.env.SOURCEID);
+        console.debug(`Limiting sensors to ${process.env.SOURCEID}, found ${sensorReadings.length}`);
+    }
 
     for (const reading of sensorReadings) {
         const system = new SensorSystem();
@@ -75,10 +80,10 @@ async function processor(source_name, source) {
     }
 
     await Promise.all(stations);
-    console.log(`ok - all ${stations.length} stations pushed`);
+    if(VERBOSE) console.log(`ok - all ${stations.length} stations pushed`);
 
     await Providers.put_measures(source_name, measures);
-    console.log(`ok - all ${measures.length} measurements pushed`);
+    if(VERBOSE) console.log(`ok - all ${measures.length} measurements pushed`);
 }
 
 async function fetchSensorData(source, apiKey) {
@@ -109,7 +114,7 @@ async function fetchSensorData(source, apiKey) {
             'ozone1'
         ].join(',')
     );
-    url.searchParams.append('max_age', 75); // Filter results to only include sensors modified or updated within the last number of seconds.
+    url.searchParams.append('max_age', 750); // Filter results to only include sensors modified or updated within the last number of seconds.
     url.searchParams.append('location_type', 0); // Filter results to only include outdoor sensors.
 
     const { body: { fields, data } } = await request({


### PR DESCRIPTION
Meant to provide more diagnostic feedback for the clarity adapter. If ran as follows you will only be shown the warnings, specifically the failed fetch warnings. The dryrun flag prevents the saving of the station and measurement files to the s3 bucket.
```
AWS_PROFILE=openaq-user SOURCE=clarity BUCKET=openaq-fetches STACK=lcs-etl-pipeline DRYRUN=1  node fetcher/index.js
```
Adding the verbose argument provides a lot more detail. I added a bit more output related to state of devices but mostly just refactored what was there to be easier to read and kept together during the parallel parts.
```
AWS_PROFILE=openaq-user SOURCE=clarity BUCKET=openaq-fetches STACK=lcs-etl-pipeline DRYRUN=1 VERBOSE=1 node fetcher/index.js
```